### PR TITLE
Add ability to specify subdirectory to run leiningen in

### DIFF
--- a/src/main/java/org/spootnik/LeiningenBuilder.java
+++ b/src/main/java/org/spootnik/LeiningenBuilder.java
@@ -36,18 +36,20 @@ import java.util.regex.Pattern;
  *
  * <p>
  * When a build is performed, the {@link #perform(AbstractBuild, Launcher, BuildListener)}
- * method will be invoked. 
+ * method will be invoked.
  *
  * @author Kohsuke Kawaguchi
  */
 public class LeiningenBuilder extends Builder {
 
     private final String task;
+    private String subdirPath;
 
     // Fields in config.jelly must match the parameter names in the "DataBoundConstructor"
     @DataBoundConstructor
-    public LeiningenBuilder(String task) {
+    public LeiningenBuilder(String task, String subdirPath) {
         this.task = task;
+        this.subdirPath = subdirPath;
     }
 
     /**
@@ -55,6 +57,10 @@ public class LeiningenBuilder extends Builder {
      */
     public String getTask() {
         return task;
+    }
+
+    public String getSubdirPath() {
+        return subdirPath;
     }
 
     @Override
@@ -74,6 +80,10 @@ public class LeiningenBuilder extends Builder {
 		listener.fatalError("invalid task: " + task);
                 build.setResult(Result.ABORTED);
 		return false;
+	}
+
+	if (subdirPath != null && subdirPath.length() > 0) {
+		workDir = new FilePath(workDir, subdirPath);
 	}
 
 	try {

--- a/src/main/resources/org/spootnik/LeiningenBuilder/config.jelly
+++ b/src/main/resources/org/spootnik/LeiningenBuilder/config.jelly
@@ -3,4 +3,10 @@
   <f:entry title="Leiningen Task Name and Arguments" field="task">
     <f:textbox default="jar" />
   </f:entry>
+  
+  <f:advanced>
+    <f:entry title="Sub-directory Path" field="subdirPath">
+      <f:textbox/>
+    </f:entry>
+  </f:advanced>
 </j:jelly>

--- a/src/main/resources/org/spootnik/LeiningenBuilder/help-subdirPath.html
+++ b/src/main/resources/org/spootnik/LeiningenBuilder/help-subdirPath.html
@@ -1,0 +1,3 @@
+<div>
+	Subdirectory path relative to workspace to run Leiningen in.
+</div>


### PR DESCRIPTION
Add the ability to specify a subdirectory to run the leiningen task in. By default this option is hidden under an 'advanced' section.

![screen shot 2013-09-03 at 10 29 52](https://f.cloud.github.com/assets/301092/1071297/118952ce-1473-11e3-9994-605fff8bf5b4.png)
